### PR TITLE
Add 'noarch' option to build script

### DIFF
--- a/recipe.yaml
+++ b/recipe.yaml
@@ -5,8 +5,9 @@ package:
   version: "{{ version }}"
 build:
   number: 1
+  noarch: python
   script:
-    - python -m pip install --no-deps --ignore-installed --use-feature=in-tree-build --prefix=$PREFIX .
+    - python -m pip install --no-deps --ignore-installed --prefix=$PREFIX .
 requirements:
   build:
     - pip
@@ -17,3 +18,13 @@ source:
   path: .
 about:
   home: https://visitor-design-pattern.readthedocs.io/en/latest/index.html
+
+test:
+  imports:
+    - visitor_design_pattern
+  requires:
+    - pytest
+  source_files:
+    - tests/**/*.py
+  commands:
+    - pytest


### PR DESCRIPTION
This commit adds the 'noarch' option to the build script in the recipe.yaml file. The 'noarch' option specifies that the package being built is architecture-independent and can be installed on any platform. Additionally, the commit includes a new 'test' section in the recipe.yaml file, which specifies the necessary imports, requirements, source files, and commands for running tests using pytest.